### PR TITLE
Fix phpstan config path

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,6 @@ parameters:
     level: 4
     paths:
         - src
-        - config
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true


### PR DESCRIPTION
## Summary
- remove the missing `config` path from `phpstan.neon.dist`

## Testing
- `composer install` *(fails: composer not found)*